### PR TITLE
Add GitHub build workflow and update to .NET 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  # Trigger when changes are pushed directly to the work branch.
+  push:
+    branches:
+      - work
+  # Trigger for pull requests targeting the work branch.
+  pull_request:
+    branches:
+      - work
+
+env:
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  TERM: xterm
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+          cache: true
+          cache-dependency-path: '**/*.csproj'
+      - name: Restore dependencies
+        run: dotnet restore CsToKotlinTranspiler.sln
+      - name: Build
+        run: dotnet build CsToKotlinTranspiler.sln --no-restore -c Release
+      - name: Test
+        run: dotnet test CsToKotlinTranspiler.sln --no-build -c Release --logger "console;verbosity=normal"

--- a/CsToKotlinTranspiler.Tests/CsToKotlinTranspiler.Tests.csproj
+++ b/CsToKotlinTranspiler.Tests/CsToKotlinTranspiler.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.5.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
   <ItemGroup>

--- a/CsToKotlinTranspiler/CsToKotlin.csproj
+++ b/CsToKotlinTranspiler/CsToKotlin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test using .NET 9
- upgrade projects and test packages to target .NET 9

## Testing
- `dotnet test CsToKotlinTranspiler.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68a57f412e7083288ad43b909179860f