### PR TITLE
Add record support and expand unit tests

### DIFF
--- a/CsToKotlinTranspiler.Tests/TranspilerTests.cs
+++ b/CsToKotlinTranspiler.Tests/TranspilerTests.cs
@@ -36,7 +36,7 @@ public class TranspilerTests
         Assert.Contains("for(s in strings)", kt);
     }
 
-    [Fact(Skip = "LINQ translation not implemented")]
+    [Fact]
     public void TranslatesLinq()
     {
         var code = "using System.Linq;\nclass Example { void Linq() { int[] ints = {1,2,3,4,5}; var big = ints.Where(i => i > 4).Select(i => i * 2).ToList(); } }";
@@ -44,7 +44,7 @@ public class TranspilerTests
         Assert.Contains("ints.filter", kt);
     }
 
-    [Fact(Skip = "Delegate translation not implemented")]
+    [Fact]
     public void TranslatesDelegates()
     {
         var code = "using System;\nclass Example { void Delegates() { Action<int,string> del = (a,b)=>{ Console.WriteLine(\"{0} {1}\", a, b); }; del(1,\"x\"); } }";
@@ -102,11 +102,32 @@ public class TranspilerTests
         Assert.Contains("fun add", kt);
     }
 
-    [Fact(Skip = "Record translation not implemented")]
+    [Fact]
     public void TranslatesRecord()
     {
-        var code = "public record Person(string Name, int Age);";
+        var code = "public record Person(string Name, int Age);"; // record -> data class
         var kt = KotlinTranspiler.Transpile(code);
         Assert.Contains("data class Person", kt);
+        Assert.Contains("val name : String", kt);
+        Assert.Contains("val age : Int", kt);
+    }
+
+    [Fact]
+    public void TranslatesSwitchStatement()
+    {
+        var code = "class Example { string Foo(int x) { switch(x) { case 1: return \"a\"; default: return \"b\"; } } }"; // switch -> when
+        var kt = KotlinTranspiler.Transpile(code);
+        Assert.Contains("when (tmp)", kt);
+        Assert.Contains("1 ->", kt);
+        Assert.Contains("else ->", kt);
+    }
+
+    [Fact]
+    public void TranslatesTryCatch()
+    {
+        var code = "using System; class Example { void Foo() { try { Console.WriteLine(\"a\"); } catch(Exception ex) { Console.WriteLine(ex.Message); } } }"; // try/catch preserved
+        var kt = KotlinTranspiler.Transpile(code);
+        Assert.Contains("try", kt);
+        Assert.Contains("catch (ex : Exception)", kt);
     }
 }

--- a/CsToKotlinTranspiler/KotlinTranspilerVisitor.cs
+++ b/CsToKotlinTranspiler/KotlinTranspilerVisitor.cs
@@ -194,6 +194,50 @@ namespace CsToKotlinTranspiler
             }
         }
 
+        public override void VisitRecordDeclaration(RecordDeclarationSyntax node)
+        {
+            // Translate C# record declarations into Kotlin data classes
+            NewLine();
+            WriteClassModifiers(node.Modifiers);
+            Write($"data class {node.Identifier}");
+
+            if (node.ParameterList != null)
+            {
+                Write("(");
+                Delimit(node.ParameterList.Parameters, p =>
+                {
+                    var name = ToCamelCase(p.Identifier.Text);
+                    var t = TranslateType(p.Type);
+                    Write($"val {name} : {t}");
+                });
+                Write(")");
+            }
+            else
+            {
+                Write("()");
+            }
+
+            if (node.BaseList != null)
+            {
+                Write(" : ");
+                Delimit(node.BaseList.Types, t =>
+                {
+                    var tn = TranslateType(t.Type);
+                    Write(tn);
+                });
+            }
+
+            Write(" {");
+            NewLine();
+            _indent++;
+            foreach (var m in node.Members)
+            {
+                Visit(m);
+            }
+            _indent--;
+            IndentWriteLine("}");
+        }
+
         private void WriteObject(ClassDeclarationSyntax node)
         {
             NewLine();


### PR DESCRIPTION
## Summary
- handle C# record declarations by emitting Kotlin data classes
- enable LINQ and delegate tests
- add tests for records, switch statements, and try/catch blocks

## Testing
- `dotnet test` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a5a3245483289a3be7f452b849be