### PR TITLE
Expand DSL with regex, encoding, and bit converter support

### DIFF
--- a/CsToKotlinTranspiler.Tests/TranspilerTests.cs
+++ b/CsToKotlinTranspiler.Tests/TranspilerTests.cs
@@ -130,4 +130,28 @@ public class TranspilerTests
         Assert.Contains("try", kt);
         Assert.Contains("catch (ex : Exception)", kt);
     }
+
+    [Fact]
+    public void TranslatesRegex()
+    {
+        var code = "using System.Text.RegularExpressions; class Example { void Foo() { var ok = Regex.IsMatch(\"abc\", \"a.c\"); } }";
+        var kt = KotlinTranspiler.Transpile(code);
+        Assert.Contains("Regex(\"a.c\").containsMatchIn(\"abc\")", kt);
+    }
+
+    [Fact]
+    public void TranslatesEncodingUtf8()
+    {
+        var code = "using System.Text; class Example { void Foo(byte[] b) { var s = Encoding.UTF8.GetString(b); } }";
+        var kt = KotlinTranspiler.Transpile(code);
+        Assert.Contains("String(b, Charsets.UTF_8)", kt);
+    }
+
+    [Fact]
+    public void TranslatesBitConverter()
+    {
+        var code = "using System; class Example { int Foo(byte[] b) { return BitConverter.ToInt32(b,0); } }";
+        var kt = KotlinTranspiler.Transpile(code);
+        Assert.Contains("ByteBuffer.wrap(b).order(ByteOrder.LITTLE_ENDIAN).getInt(0)", kt);
+    }
 }


### PR DESCRIPTION
## Summary
- extend DSL setup with mappings for Regex, Encoding.UTF8 helpers, and BitConverter conversions
- add unit tests covering new DSL features

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5b9dd8dcc8328bcf332aaeb4384b9