### PR TITLE
Allow configuring source and output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ Transpiler from C# to Kotlin.
 
 Very early pre alpha
 
+## Usage
+
+The transpiler expects the path to a C# solution and an output directory for the generated Kotlin files.
+
+```bash
+dotnet run --project CsToKotlinTranspiler -- <solution.sln> <output-directory>
+```
+
+You may also provide the paths via environment variables:
+
+```bash
+export CS2KOTLIN_SRC=/path/to/solution.sln
+export CS2KOTLIN_OUT=./kotlinOutput
+dotnet run --project CsToKotlinTranspiler
+```
+
+If neither arguments nor environment variables are supplied, the tool uses default paths.
+
 Demo:
 
 ```csharp


### PR DESCRIPTION
## Summary
- allow specifying solution and output directories via command line args or environment variables
- log diagnostic information when the workspace fails
- document command-line usage and environment variable support

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b8f89da48328b161e8b54cd38654