### PR TITLE
Handle missing type symbols when translating object creation

### DIFF
--- a/CsToKotlinTranspiler/TypeHelpers.cs
+++ b/CsToKotlinTranspiler/TypeHelpers.cs
@@ -216,11 +216,26 @@ namespace CsToKotlinTranspiler
         private string TranslateObjectCreator(TypeSyntax type)
         {
             var s = GetTypeSymbol(type);
+            if (s == null)
+            {
+                // If Roslyn cannot resolve the type symbol, fall back to the raw
+                // type syntax so the transpiler can continue without crashing.
+                return $"/* {type.ToFullString().Trim()} */";
+            }
+
             return TranslateObjectCreator(s);
         }
 
         private string TranslateObjectCreator(ITypeSymbol s)
         {
+            if (s == null)
+            {
+                // Unknown types are emitted as empty so callers can decide how
+                // to handle them (typically resulting in a comment from the call
+                // site).
+                return string.Empty;
+            }
+
             switch (s.Name)
             {
                 case nameof(HashSet<object>): return "mutableSetOf";


### PR DESCRIPTION
## Summary
- Guard object creation translation against missing Roslyn type symbols to avoid null reference exceptions

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet run --project CsToKotlinCli -- CsToKotlinCli/Program.cs`
- `MSBUILDTERMINALLOGGER=false dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d73e297883288a1c0a711656756c