### PR TITLE
Use type name for unknown object creations

### DIFF
--- a/CsToKotlinTranspiler.Tests/TranspilerTests.cs
+++ b/CsToKotlinTranspiler.Tests/TranspilerTests.cs
@@ -22,6 +22,17 @@ public class TranspilerTests
     }
 
     [Fact]
+    public void TranslatesUnknownObjectCreation()
+    {
+        // Types that aren't resolved by Roslyn should still emit their name
+        // so simple constructor calls are preserved in the output.
+        var code = "using System; class Example { void Main() { Console.WriteLine(new Rule(\\\"foo\\\")); } }";
+        var kt = KotlinTranspiler.Transpile(code);
+        Assert.Contains("Rule(", kt);
+        Assert.DoesNotContain("/* Rule */", kt);
+    }
+
+    [Fact]
     public void TranslatesConditionalOperator()
     {
         var code = "class Example { string Foo() { return 1 > 2 ? \"a\" : \"b\"; } }";

--- a/CsToKotlinTranspiler/TypeHelpers.cs
+++ b/CsToKotlinTranspiler/TypeHelpers.cs
@@ -218,9 +218,10 @@ namespace CsToKotlinTranspiler
             var s = GetTypeSymbol(type);
             if (s == null)
             {
-                // If Roslyn cannot resolve the type symbol, fall back to the raw
-                // type syntax so the transpiler can continue without crashing.
-                return $"/* {type.ToFullString().Trim()} */";
+                // Roslyn couldn't resolve the symbol, so just emit the type name
+                // directly. This allows simple constructor calls like `Rule()`
+                // to be emitted instead of being commented out.
+                return type.ToString();
             }
 
             return TranslateObjectCreator(s);


### PR DESCRIPTION
## Summary
- emit object construction using the original type name when no special mapping is known
- test that unresolved types are instantiated instead of commented out

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a5daf55db083289d3356d21479fd00