### PR TITLE
Handle unresolved symbols when transpiling method calls

### DIFF
--- a/CsToKotlinTranspiler/KotlinTranspilerVisitor.cs
+++ b/CsToKotlinTranspiler/KotlinTranspilerVisitor.cs
@@ -869,10 +869,9 @@ namespace CsToKotlinTranspiler
             var memberName = node.Name.ToString();
             var sym = _model.GetSymbolInfo(node).Symbol;
             var containingTypeName = sym?.ContainingType?.Name;
-            if (sym.Kind == SymbolKind.Method)
-            {
-            }
-
+            // When Roslyn cannot resolve the symbol (e.g. external libraries not referenced)
+            // `sym` will be null. In that case we still emit the member access without
+            // attempting to inspect its kind to avoid null reference exceptions.
             Visit(node.Expression);
             Write(".");
             var name = memberName;
@@ -882,7 +881,7 @@ namespace CsToKotlinTranspiler
                 return;
             }
 
-            if (sym.Kind == SymbolKind.Method || sym.Kind == SymbolKind.Property)
+            if (sym != null && (sym.Kind == SymbolKind.Method || sym.Kind == SymbolKind.Property))
             {
                 name = ToCamelCase(name);
             }

--- a/CsToKotlinTranspiler/TypeHelpers.cs
+++ b/CsToKotlinTranspiler/TypeHelpers.cs
@@ -273,7 +273,13 @@ namespace CsToKotlinTranspiler
                         }
 
                         Write(name);
-                        if (sym != null && sym.Kind == SymbolKind.Method)
+                        // If Roslyn cannot resolve the symbol (sym == null) we still
+                        // want to emit the argument list. Otherwise method calls such
+                        // as AnsiConsole.MarkupLine("foo") are rendered without
+                        // parentheses and arguments. InvocationExpression always
+                        // represents a call, so default to writing the arguments when
+                        // the symbol is unknown.
+                        if (sym == null || sym.Kind == SymbolKind.Method)
                         {
                             Visit(node.ArgumentList);
                         }


### PR DESCRIPTION
## Summary
- Ensure invocation expressions emit arguments even when Roslyn can't resolve the method symbol
- Guard member access translation against null symbols to avoid crashes

## Testing
- `dotnet run --project CsToKotlinCli -- CsToKotlinCli/Program.cs`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ded59dd8832889032c4df379d8f5